### PR TITLE
More flag issues fixed

### DIFF
--- a/ddoc2.js
+++ b/ddoc2.js
@@ -519,9 +519,7 @@ if (!debugOnly) {
 		  wholist.list_long();
 		  break;
 		case 'x':
-		  bbs.sys_status ^= SS_MOFF;
 		  express.sendX();
-		  bbs.sys_status ^= SS_MOFF;
 		  break;
 		case 'W':
 		  wholist.list_short(wholist.populate());

--- a/ddoc2.js
+++ b/ddoc2.js
@@ -337,7 +337,7 @@ docIface = {
 	}
 
 	//turn on asynchronous message arrival
-	bbs.sys_status |= SS_MOFF;
+	bbs.sys_status &=~ SS_MOFF;
 	//turn off time limit
 	user.security.exemptions |= UFLAG_H;
 	//this is how it SHOULD work, anyway

--- a/load/dexpress.js
+++ b/load/dexpress.js
@@ -224,7 +224,7 @@ express = {
    *	Negative value for fuggup
    */
   sendX : function() {
-	var recip, ouah, mTxt;
+	var recip, mTxt;
 
 	//turn off incoming messages for a bit
 	bbs.sys_status |= SS_MOFF;

--- a/load/dmbase.js
+++ b/load/dmbase.js
@@ -131,9 +131,7 @@ msg_base = {
 		  break;
 		case 'x':
 		case 'X':
-		  bbs.sys_status ^= SS_MOFF;
 		  express.sendX();
-		  bbs.sys_status ^= SS_MOFF;
 		  break;
                 default:
                   console.putmsg(normal + yellow + "Invalid choice\n");


### PR DESCRIPTION
Let sendX() handle disabling and enabling of the SS_MOFF flag itself.  Before this commit, the flag was being flipped before, during, and after sendX, causing all sorts of oddness.

We need to clear (&=~) not set (|=) SS_MOFF in initDdoc.  Having this flag enabled means Messages are OFF (MOFF)