### PR TITLE
Hotfix: fixed login's NaN

### DIFF
--- a/ddoc2.js
+++ b/ddoc2.js
@@ -476,12 +476,13 @@ docIface = {
 
 	//load room settings
 	try {
-          if (userSettings.debug.file_io) {
+          /*if (userSettings.debug.file_io) {
               console.putmsg(cyan + "Looking for room info file: " +
                 roomData.fileIO.roomRecFilename + "\n");  //why no workee? 8o|
-          }
+          }     //this should be "/sbbs/data/user/docrooms", but more than that
+                //it should be working correctly from w/in proper references WTF
 
-          /*for each(var area in msg_area.grp_list[topebaseno].code) {
+          for each(var area in msg_area.grp_list[topebaseno].code) {
 	    roomSettings[area] = roomData.fileIO.snagRoomInfoBlob(
                                               "/sbbs/data/user/docrooms",
                                               //roomData.fileIO.roomRecFilename,


### PR DESCRIPTION
The **NaN** upon login was coming from code trying to resolve the static properties indicating the location of _docrooms_.  For now these have been hardcoded.