### PR TITLE
More debugging in search of wtf for issue #140

### DIFF
--- a/load/dmbase.js
+++ b/load/dmbase.js
@@ -571,18 +571,24 @@ msg_base = {
 	  //take care of this in calling code
           //mBase.close();
           mBase = new MsgBase(mb);
-	  mBase.open();
+	  try {
+            mBase.open();
+          } catch (e) {
+              console.putmsg(red + "Ername: " + e.name + "mBase.error: " +
+                  e.message + "\n");
+              throw new dDocException("openNewMBase() Error", e.message, 1);
+          }
+
           if (userSettings.debug.message_scan) {
             console.putmsg(red + "Opened: " + mb +
         	           " allegedly . . .\n");
-	    console.putmsg(red + "mBase.error: " + mBase.error + "\n");
           }
         } catch (e) {
           console.putmsg(red + "Error opening new mBase:\n"
 		+ e.toString() + "\n");
           log("Error skipping through scanSub(): " +
             e.toString());
-          return null;  //this is where we want to throw an exception instead
+          throw new dDocException("openNewMBase() Error", e.message, 2);
         }
 
 	return mBase;
@@ -625,8 +631,12 @@ msg_base = {
 	}
 
 	tmpPtr = sBoard.scan_ptr;
+        //tmpPtr = sBoard.ptridx;
+        //tmpPtr = mBase.cfg.ptridx;
 	if (userSettings.debug.message_scan) {
 	  console.putmsg("sBoard.scan_ptr = " + sBoard.scan_ptr + "\n");
+          console.putmsg("sBoard.ptridx = " + sBoard.ptridx + "\n");
+          console.putmsg("mBase.cfg.ptridx = " + mBase.cfg.ptridx + "\n");
 	  console.putmsg("mBase.first_msg = " + mBase.first_msg + "\n");
 	  console.putmsg("mBase.total_msgs = " + mBase.total_msgs + "\n");
 	  console.putmsg("mBase.last_msg = " + mBase.last_msg + "\n");


### PR DESCRIPTION
After some more in-depth debugging (still there, but mostly commented out) about why the negative message scan numbers are being hit and forward scan isn't working, but only for _Ddoctest_, I believe that I've found it's due to something having corrupted the pointers for that particular user.  None of the other users have it, even if they switch to **Ddoc** and login the same way.  Code that I know was ironclad back in the day has the bug, it's got to be a corrupted last message pointer for _Ddoctest_.  So now I need to go about figuring how to fix that; good news is that the code isn't borked.