### PR TITLE
Closed #156; removed code setting message pointers to all read

### DIFF
--- a/ddoc2.js
+++ b/ddoc2.js
@@ -380,12 +380,15 @@ docIface = {
 	*/
     skip: function () {
 	// mark all messages as read in current room
-	var mBase = msg_base.openNewMBase(bbs.cursub_code);
+	//var mBase = msg_base.openNewMBase(bbs.cursub_code);
 
+        /* this is the code that is leaving skip adjusting the message pointers
+         * that we really don't want to eff with; they need to stay the same
+         * for the next return to this sub
 	if (mBase != null) {
 	    msg_area.sub[bbs.cursub_code].scan_ptr = mBase.total_msgs;
 	    mBase.close();
-	}
+	} */
 	// use findNew to change to next room with unread messages
 	this.findNew();
     },


### PR DESCRIPTION
Commented out the different bits of code that were setting the message pointers to all read when utilizing the ``skip()`` function.  Seems to be working properly, but there wasn't a chance for full testing; this may need to be revisited in the future.  Only 3 lines of code were really touched, this shouldn't be a big deal to revisit if necessary.