### PR TITLE
Fixed some syntax in commit that also closes #173 and closes #172

### DIFF
--- a/load/dmbase.js
+++ b/load/dmbase.js
@@ -591,10 +591,16 @@ msg_base = {
 	  console.putmsg("mBase.last_msg = " + mBase.last_msg + "\n");
 	}
 	
-	if (forward) {inc = 1;} else {inc = -1;}
+	if (forward) {
+            inc = 1;
+        } else {
+            inc = -1;
+        }
 	
 	// if starting in reverse from the room prompt, unskip one message
-	if (!forward) tmpPtr += 1;  // so we start with the most recently read
+	if (!forward) {
+            tmpPtr += 1;  // so we start with the most recently read
+        }
 	// message.  In all other cases we want to skip one.
 	
 	if (userSettings.debug.message_scan) {


### PR DESCRIPTION
As it says, doesn't completely fix the issue with scans stopping before the end of all subs, but this fixes issues #172 and #173, which is a significant recovery.  Posting messages and scan actually reading a new message is now taken care of again.