### PR TITLE
Hotfix message by number

### DIFF
--- a/ddoc2.js
+++ b/ddoc2.js
@@ -846,11 +846,19 @@ if (!debugOnly) {
                 case '9':   //we're going to read message by number here
                   //there will, of course, have to be some error checking for
                   //trying to hit out of bounds messages if dispMsg() doesn't
-                  //already have it
-                  console.putmsg(green + high_intensity + "Go to message #> ");
+                  //already have it; which I forgot for a long time, of course,
+                  //and now is resulting in the bug that I'm trying to fix
+                  try {
+                    msg_base.entry_level.gotoMessageByNum(uchoice);
+                  } catch (e) {
+                      console.putmsg(red + "Caught:\n" + high_intensity +
+                        e.name + "\n" + e.message + "\n\n");
+                  }
+
+                  /* console.putmsg(green + high_intensity + "Go to message #> ");
                   console.ungetstr(uchoice);    //put it back on the input stack
                   msg_base.dispMsg(new MsgBase(bbs.cursub_code),
-                                   console.getnum(maxMsgs), false);
+                                   console.getnum(maxMsgs), false); */
                   break;
                 case '$':       //change debugging flags for this user
                   var dropOut = false;

--- a/load/dmbase.js
+++ b/load/dmbase.js
@@ -643,7 +643,7 @@ msg_base = {
         msgMap = msg_base.util.remap_message_indices(mBase);
         if (msgMap.indexOf(msgNum) == -1) {
             //scroll ahead to the next valid message or end of the room
-            for (; msgNum >= mBase.last_msg; msgNum++) {
+            for (; msgNum <= mBase.last_msg; msgNum++) {
                 if (msgMap.indexOf(msgNum) != -1) {
                     //we've got a valid message
                     success = true;


### PR DESCRIPTION
While a full message read is not gone into by displaying a message by number like this, the functionality is now sufficient to pull up that exact number or the next valid message beyond that particular one (in that particular room/sub).  We'll want to put some more polish on this at some point, but for now it's good.